### PR TITLE
Addition of custom CND additions to Specs

### DIFF
--- a/README.md
+++ b/README.md
@@ -450,6 +450,22 @@ class ExampleSpec extends ProsperSpec {
 }
 ```
 
+### Adding JCR Namespaces and Node Types
+
+A number of the more common AEM, JCR, and Sling namespaces and node types are added to the in-memory repository upon
+setup of the first Spec in a set of specifications.  Additional namespaces and node types may be added at runtime by
+overriding the `addCndInputStreams` method of the `AemSpec`.  This method is intended to return a list of `InputStream`
+objects each of which should be the input stream of a CND file.  For more information on the CND node type notation,
+see [Node Type Notation](http://jackrabbit.apache.org/node-type-notation.html) on the Jackrabbit website.  An example of
+an overridden `addCndInputStreams` taken from the `ProsperSpecSpec` internal test is presented below.
+
+```groovy
+@Override
+List<InputStream> addCndInputStreams() {
+    [this.class.getResourceAsStream("/SLING-INF/testnodetypes/test.cnd")]
+}
+```
+
 ### Mocking Services
 
 OSGi services can be mocked (fully or partially) using Spock's [mocking API](http://docs.spockframework.org/en/latest/interaction_based_testing.html#creating-mock-objects).  Classes that inject services using the [Apache Felix SCR annotations](http://felix.apache.org/documentation/subprojects/apache-felix-maven-scr-plugin/scr-annotations.html) (as in the example servlet below) should use `protected` visibility to allow setting of service fields to mocked instances during testing.

--- a/pom.xml
+++ b/pom.xml
@@ -328,6 +328,14 @@
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.apache.tika</groupId>
+            <artifactId>tika-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.tika</groupId>
+            <artifactId>tika-parsers</artifactId>
+        </dependency>
 
         <!-- additional dependencies not inherited from parent -->
         <dependency>

--- a/src/main/groovy/com/citytechinc/aem/prosper/specs/AemSpec.groovy
+++ b/src/main/groovy/com/citytechinc/aem/prosper/specs/AemSpec.groovy
@@ -31,6 +31,7 @@ abstract class AemSpec extends Specification {
      */
     def setupSpec() {
         sessionInternal = getRepository().loginAdministrative(null)
+        registerCustomNodeTypes()
     }
 
     /**
@@ -68,6 +69,16 @@ abstract class AemSpec extends Specification {
         session.save()
     }
 
+    /**
+     * Add JCR namespaces and node types based on any number of CND file input streams.  Specs should override this
+     * method to add CND files to be registered at runtime.
+     *
+     * @return list of InputStreams to add
+     */
+    List<InputStream> addCndInputStreams() {
+        Collections.emptyList()
+    }
+
     // internals
 
     @Synchronized
@@ -77,7 +88,7 @@ abstract class AemSpec extends Specification {
 
             repository = RepositoryUtil.getRepository()
 
-            registerNodeTypes()
+            registerCoreNodeTypes()
 
             addShutdownHook {
                 RepositoryUtil.stopRepository()
@@ -87,7 +98,7 @@ abstract class AemSpec extends Specification {
         repository
     }
 
-    protected def registerNodeTypes() {
+    protected def registerCoreNodeTypes() {
         def session = repository.loginAdministrative(null)
 
         NODE_TYPES.each { type ->
@@ -98,4 +109,13 @@ abstract class AemSpec extends Specification {
 
         session.logout()
     }
+
+    protected def registerCustomNodeTypes() {
+        def session = repository.loginAdministrative(null)
+
+        addCndInputStreams().each { RepositoryUtil.registerNodeType(session, it) }
+
+        session.logout()
+    }
+
 }

--- a/src/main/resources/SLING-INF/testnodetypes/test.cnd
+++ b/src/main/resources/SLING-INF/testnodetypes/test.cnd
@@ -1,0 +1,3 @@
+<prospertest = 'http://www.citytechinc.com/ns/prosper/test/'>
+
+[prospertest:TestType] > nt:unstructured

--- a/src/test/groovy/com/citytechinc/aem/prosper/specs/ProsperSpecSpec.groovy
+++ b/src/test/groovy/com/citytechinc/aem/prosper/specs/ProsperSpecSpec.groovy
@@ -45,9 +45,18 @@ class ProsperSpecSpec extends ProsperSpec {
         [(String.class): { "world" }]
     }
 
+    @Override
+    List<InputStream> addCndInputStreams() {
+        [this.class.getResourceAsStream("/SLING-INF/testnodetypes/test.cnd")]
+    }
+
     def setupSpec() {
         pageBuilder.content {
-            home()
+            home() {
+                "jcr:content"() {
+                    testcontent("prospertest:TestType")
+                }
+            }
         }
     }
 
@@ -125,5 +134,13 @@ class ProsperSpecSpec extends ProsperSpec {
 
         expect:
         resource.adaptTo(Node)
+    }
+
+    def "check node type for node with custom type"() {
+        setup:
+        def node = getNode("/content/home/jcr:content/testcontent")
+
+        expect:
+        node.isNodeType("prospertest:TestType")
     }
 }


### PR DESCRIPTION
Wanted to get some review of this addition before pushing it into develop.  Specifically I wanted some consideration of the fact that once one spec sets up custom namespaces or node types these can not (easily) be removed or "cleaned" and as such, any future specs will run in a repository with the custom node types.  
